### PR TITLE
Suggestion: Corner radius for the elevated buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ ElevatedLayerButton(
   topDecoration: BoxDecoration(  
     color: Colors.amber,  
     border: Border.all(),  
+    borderRadius: BorderRadius.circular(20)
   ),
   topLayerChild: Text(  
     "ElevatedLayerButton()",  
@@ -46,6 +47,7 @@ ElevatedLayerButton(
   baseDecoration: BoxDecoration(  
     color: Colors.green,  
     border: Border.all(),  
+    borderRadius: BorderRadius.circular(20),
   ),  
 ),
 ```

--- a/lib/elevated_layer_button.dart
+++ b/lib/elevated_layer_button.dart
@@ -28,6 +28,9 @@ class ElevatedLayerButton extends StatefulWidget {
   /// Define Top Layer Child [Widget] for button
   final Widget? topLayerChild;
 
+  /// if anyone wants to add slightly rounded corners
+  final BorderRadius? borderRadius;
+
   const ElevatedLayerButton({
     Key? key,
     required this.buttonHeight,
@@ -38,6 +41,7 @@ class ElevatedLayerButton extends StatefulWidget {
     this.baseDecoration,
     this.topDecoration,
     this.topLayerChild,
+    this.borderRadius,
   }) : super(key: key);
 
   @override
@@ -69,10 +73,13 @@ class _ElevatedLayerButtonState extends State<ElevatedLayerButton> {
                 child: Container(
                   width: (widget.buttonWidth ?? 100) - 10,
                   height: (widget.buttonHeight ?? 40) - 10,
-                  decoration: widget.baseDecoration ??
-                      const BoxDecoration(
-                        color: Colors.black,
-                      ),
+                  decoration: widget.baseDecoration?.copyWith(
+                    borderRadius: widget.borderRadius,
+                    border: Border.all(color: Colors.black), // Specify the border color here
+                  ) ??
+                  const BoxDecoration(
+                    color: Colors.black,
+                  ),
                 ),
               ),
               AnimatedPositioned(
@@ -91,10 +98,13 @@ class _ElevatedLayerButtonState extends State<ElevatedLayerButton> {
                   width: (widget.buttonWidth ?? 100) - 10,
                   height: (widget.buttonHeight ?? 100) - 10,
                   alignment: Alignment.center,
-                  decoration: widget.topDecoration ??
-                      BoxDecoration(
-                        border: Border.all(color: Colors.black),
-                      ),
+                  decoration: widget.topDecoration?.copyWith(
+                      borderRadius: widget.borderRadius,
+                      border: Border.all(color: Colors.black), // Specify the border color here
+                    ) ??
+                    const BoxDecoration(
+                      color: Colors.black,
+                    ),
                   child: widget.topLayerChild,
                 ),
               ),

--- a/lib/elevated_layer_button.dart
+++ b/lib/elevated_layer_button.dart
@@ -75,7 +75,7 @@ class _ElevatedLayerButtonState extends State<ElevatedLayerButton> {
                   height: (widget.buttonHeight ?? 40) - 10,
                   decoration: widget.baseDecoration?.copyWith(
                     borderRadius: widget.borderRadius,
-                    border: Border.all(color: Colors.black), // Specify the border color here
+                    border: Border.all(color: Colors.black),
                   ) ??
                   const BoxDecoration(
                     color: Colors.black,
@@ -100,7 +100,7 @@ class _ElevatedLayerButtonState extends State<ElevatedLayerButton> {
                   alignment: Alignment.center,
                   decoration: widget.topDecoration?.copyWith(
                       borderRadius: widget.borderRadius,
-                      border: Border.all(color: Colors.black), // Specify the border color here
+                      border: Border.all(color: Colors.black),
                     ) ??
                     const BoxDecoration(
                       color: Colors.black,


### PR DESCRIPTION
We could add a bit of a rounded corner to the elevated buttons if needed, for that a border-radius parameter could be introduced similar to the horizontal_fill_button. Please consider this pr as only an idea for the current button.